### PR TITLE
fix: make the hospital description pane scrollable on the mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
             </div>
 
             <!-- The hospital description panel -->
-            <div class="fl-mapviz-hospital-panel" role="region" aria-live="polite">
+            <div class="fl-mapviz-hospital-panel fl-mapviz-hospital-panel-hidden" role="region" aria-live="polite">
                 <button type="button" class="fl-mapviz-expand-collapse-button" aria-expanded="true" aria-label="hospital panel" aria-controls="fl-mapviz-hospital-content">
                     <svg role="presentation" class="fl-mapviz-collapse-button">
                         <use xlink:href="#ArrowDown"></use>
@@ -313,48 +313,44 @@
                 <h2 class="fl-mapviz-hospital-title">
                     Hospital 2
                 </h2>
-                <div class="fl-mapviz-hospital-overall" id="fl-mapviz-hospital-content">
-	                <div class="fl-mapviz-hospital-description">
-	                    <div class="fl-mapviz-hospital-description-prov">
-	                        <div>
-	                            <svg role="presentation" class="fl-mapviz-filter-icon">
-	                                <use xlink:href="#DataVerified"></use>
-	                            </svg>
-	                        </div>
-	                        <span>UI elements are sourced from verified data
-	                        </span>
-	                    </div>
-	                    <div class="fl-mapviz-hospital-description-content">
-	                        <div><b>Hours:</b> <span class="fl-mapviz-hospital-hours">8:00 am to 12:00 pm, from Monday to Friday.</span>
-	                        </div>
-	                        <div><b>Location</b></div>
-	                        <div class="fl-mapviz-hospital-address">600 University Ave, Toronto, ON M5G 1X5</div>
-	                        <div class="fl-mapviz-hospital-phone">+1 416-586-5054</div>
-	                        <a href="www.mountsinai.on.ca" target="_blank" class="fl-mapviz-hospital-website">www.mountsinai.on.ca</a>
-	                    </div>
-	                </div>
-	                <div class="fl-mapviz-hospital-features">
-	                    <div class="fl-mapviz-hospital-features-prov">
-	                        <div>
-	                            <svg role="presentation" class="fl-mapviz-filter-icon">
-	                                <use xlink:href="#DataSynthetic"></use>
-	                            </svg>
-	                        </div>
-	                        <span>UI elements are sourced from synthetic data
-	                        </span>
-	                    </div>
-	                    <div class="fl-mapviz-hospital-features-content">
-	                         <h3>Accessibility features</h3>
-	                         <div class="fl-mapviz-hospital-feature-list">
-	                             <div class="fl-mapviz-hospital-feature">
-			                         <svg role="presentation" class="fl-mapviz-filter-icon">
-		                                 <use xlink:href="#Parking"></use>
-		                             </svg>
-		                             <div>Accessible parking with permit</div>
-		                         </div>
-	                         </div>
-	                    </div>
-	                </div>
+                <div class="fl-mapviz-hospital" id="fl-mapviz-hospital-content">
+                    <div class="fl-mapviz-hospital-description-prov">
+                        <div>
+                            <svg role="presentation" class="fl-mapviz-filter-icon">
+                                <use xlink:href="#DataVerified"></use>
+                            </svg>
+                        </div>
+                        <span>UI elements are sourced from verified data
+                        </span>
+                    </div>
+                    <div class="fl-mapviz-hospital-features-prov">
+                        <div>
+                            <svg role="presentation" class="fl-mapviz-filter-icon">
+                                <use xlink:href="#DataSynthetic"></use>
+                            </svg>
+                        </div>
+                        <span>UI elements are sourced from synthetic data
+                        </span>
+                    </div>
+                    <div class="fl-mapviz-hospital-description">
+                        <div><b>Hours:</b> <span class="fl-mapviz-hospital-hours">8:00 am to 12:00 pm, from Monday to Friday.</span>
+                        </div>
+                        <div><b>Location</b></div>
+                        <div class="fl-mapviz-hospital-address">600 University Ave, Toronto, ON M5G 1X5</div>
+                        <div class="fl-mapviz-hospital-phone">+1 416-586-5054</div>
+                        <a href="www.mountsinai.on.ca" target="_blank" class="fl-mapviz-hospital-website">www.mountsinai.on.ca</a>
+                    </div>
+                    <div class="fl-mapviz-hospital-features">
+                         <h3>Accessibility features</h3>
+                         <div class="fl-mapviz-hospital-feature-list">
+                             <div class="fl-mapviz-hospital-feature">
+                                 <svg role="presentation" class="fl-mapviz-filter-icon">
+                                     <use xlink:href="#Parking"></use>
+                                 </svg>
+                                 <div>Accessible parking with permit</div>
+                             </div>
+                         </div>
+                    </div>
                 </div>
             </div>
 

--- a/src/css/scss/fluid-covid-map-viz.scss
+++ b/src/css/scss/fluid-covid-map-viz.scss
@@ -120,6 +120,8 @@ button {
 #fl-mapviz-provenance {
     background-color: #ffcb70;
     font-size: 0.8rem;
+    height: 3rem;
+    overflow-y: scroll;
     padding: 3px 5px;
     width: 100%;
     ul {
@@ -500,16 +502,8 @@ button {
 /******** The hospital description panel ********/
 
 /* hide the hospital description panel at the page load */
-.fl-mapviz-hospital-panel {
+.fl-mapviz-hospital-panel-hidden {
     display: none;
-
-    .fl-mapviz-hospital-description, .fl-mapviz-hospital-features {
-        overflow-y: auto;
-
-        & > div {
-            padding: 1rem;
-        }
-    }
 }
 
 .fl-mapviz-hospital-title {
@@ -518,45 +512,37 @@ button {
     padding: 0.5rem;
 }
 
-.fl-mapviz-hospital-description {
-    flex-basis: 70%;
-    border-right: 4px solid #ACACAC;
-}
+.fl-mapviz-hospital {
+    display: grid;
+    grid-template-columns: 50% 50%;
+    overflow-y: scroll;
 
-.fl-mapviz-hospital-description-prov {
-    @extend .fl-mapviz-hospital-prov;
-}
-
-.fl-mapviz-hospital-features {
-    flex-basis: 30%;
-}
-
-.fl-mapviz-hospital-feature {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    
-    svg {
-        flex-basis: 15%
+    .fl-mapviz-hospital-description-prov,
+    .fl-mapviz-hospital-description {
+        border-right: 4px solid #ACACAC;
     }
-}
 
-.fl-mapviz-hospital-prov {
-    flex-direction: row;
-    display: flex;
-    align-items: center;
-    background: #E7E7E7;
-    height: 4rem;
-}
+    .fl-mapviz-hospital-description-prov,
+    .fl-mapviz-hospital-features-prov {
+        flex-direction: row;
+        display: flex;
+        align-items: center;
+        background: #E7E7E7;
+        padding: 0.5rem 0;
+    }
 
+    .fl-mapviz-hospital-features {
+        h3 {
+            padding-left: 1rem;
+        }
 
-.fl-mapviz-hospital-features-prov {
-    @extend .fl-mapviz-hospital-prov;
-}
-
-.fl-mapviz-hospital-overall {
-    flex-direction: row;
-    display: flex;
+        .fl-mapviz-hospital-feature {
+            align-items: center;
+            display: flex;
+            flex-direction: row;
+            padding-left: 1rem;
+        }
+    }
 }
 
 /******** The panel control buttons ********/
@@ -677,6 +663,8 @@ button {
     /******** The disclaimer **********/
     #fl-mapviz-provenance {
         font-size: 1.125rem;
+        height: auto;
+        overflow-y: none;
         padding: 1rem;
     }
 
@@ -860,26 +848,6 @@ button {
 }
 
 @media screen and (max-width: 1024px) {
-    #fl-mapviz-provenance {
-        height: 3rem;
-        overflow-y: scroll;
-    }
-
-    .fl-mapviz-hospital-panel {
-
-        .fl-mapviz-hospital-description, .fl-mapviz-hospital-features {
-            overflow-y: scroll;
-        }
-    }
-
-    .fl-mapviz-hospital-description {
-        flex-basis: 50%;
-    }
-
-    .fl-mapviz-hospital-features {
-        flex-basis: 50%;
-    }
-
     /* A special class defined at the bottom of the css file so that it only available and affect the mobile view.
     The effect doesn't apply to the desktop view at all. */
     .fl-mapviz-hidden-on-mobile {

--- a/src/html/template.html
+++ b/src/html/template.html
@@ -234,7 +234,7 @@
             </div>
 
             <!-- The hospital description panel -->
-            <div class="fl-mapviz-hospital-panel" role="region" aria-live="polite">
+            <div class="fl-mapviz-hospital-panel fl-mapviz-hospital-panel-hidden" role="region" aria-live="polite">
                 <button type="button" class="fl-mapviz-expand-collapse-button" aria-expanded="true" aria-label="hospital panel" aria-controls="fl-mapviz-hospital-content">
                     <svg role="presentation" class="fl-mapviz-collapse-button">
                         <use xlink:href="#ArrowDown"></use>
@@ -256,47 +256,43 @@
                 <h2 class="fl-mapviz-hospital-title">
                     Hospital 2
                 </h2>
-                <div class="fl-mapviz-hospital-overall" id="fl-mapviz-hospital-content">
+                <div class="fl-mapviz-hospital" id="fl-mapviz-hospital-content">
+                    <div class="fl-mapviz-hospital-description-prov">
+                        <div>
+                            <svg role="presentation" class="fl-mapviz-filter-icon">
+                                <use xlink:href="#DataVerified"></use>
+                            </svg>
+                        </div>
+                        <span>UI elements are sourced from verified data
+                        </span>
+                    </div>
+                    <div class="fl-mapviz-hospital-features-prov">
+                        <div>
+                            <svg role="presentation" class="fl-mapviz-filter-icon">
+                                <use xlink:href="#DataSynthetic"></use>
+                            </svg>
+                        </div>
+                        <span>UI elements are sourced from synthetic data
+                        </span>
+                    </div>
                     <div class="fl-mapviz-hospital-description">
-                        <div class="fl-mapviz-hospital-description-prov">
-                            <div>
-                                <svg role="presentation" class="fl-mapviz-filter-icon">
-                                    <use xlink:href="#DataVerified"></use>
-                                </svg>
-                            </div>
-                            <span>UI elements are sourced from verified data
-                            </span>
+                        <div><b>Hours:</b> <span class="fl-mapviz-hospital-hours">8:00 am to 12:00 pm, from Monday to Friday.</span>
                         </div>
-                        <div class="fl-mapviz-hospital-description-content">
-                            <div><b>Hours:</b> <span class="fl-mapviz-hospital-hours">8:00 am to 12:00 pm, from Monday to Friday.</span>
-                            </div>
-                            <div><b>Location</b></div>
-                            <div class="fl-mapviz-hospital-address">600 University Ave, Toronto, ON M5G 1X5</div>
-                            <div class="fl-mapviz-hospital-phone">+1 416-586-5054</div>
-                            <a href="www.mountsinai.on.ca" target="_blank" class="fl-mapviz-hospital-website">www.mountsinai.on.ca</a>
-                        </div>
+                        <div><b>Location</b></div>
+                        <div class="fl-mapviz-hospital-address">600 University Ave, Toronto, ON M5G 1X5</div>
+                        <div class="fl-mapviz-hospital-phone">+1 416-586-5054</div>
+                        <a href="www.mountsinai.on.ca" target="_blank" class="fl-mapviz-hospital-website">www.mountsinai.on.ca</a>
                     </div>
                     <div class="fl-mapviz-hospital-features">
-                        <div class="fl-mapviz-hospital-features-prov">
-                            <div>
-                                <svg role="presentation" class="fl-mapviz-filter-icon">
-                                    <use xlink:href="#DataSynthetic"></use>
-                                </svg>
-                            </div>
-                            <span>UI elements are sourced from synthetic data
-                            </span>
-                        </div>
-                        <div class="fl-mapviz-hospital-features-content">
-                             <h3>Accessibility features</h3>
-                             <div class="fl-mapviz-hospital-feature-list">
-                                 <div class="fl-mapviz-hospital-feature">
-                                     <svg role="presentation" class="fl-mapviz-filter-icon">
-                                         <use xlink:href="#Parking"></use>
-                                     </svg>
-                                     <div>Accessible parking with permit</div>
-                                 </div>
+                         <h3>Accessibility features</h3>
+                         <div class="fl-mapviz-hospital-feature-list">
+                             <div class="fl-mapviz-hospital-feature">
+                                 <svg role="presentation" class="fl-mapviz-filter-icon">
+                                     <use xlink:href="#Parking"></use>
+                                 </svg>
+                                 <div>Accessible parking with permit</div>
                              </div>
-                        </div>
+                         </div>
                     </div>
                 </div>
             </div>

--- a/src/js/covidMap.js
+++ b/src/js/covidMap.js
@@ -296,7 +296,7 @@ fluid.defaults("fluid.covidMap.map", {
         hospitalBackButton: ".fl-mapviz-hospital-back-button",
         hospitalPanel: ".fl-mapviz-hospital-panel",
         hospitalProvenance: ".fl-mapviz-hospital-description-prov",
-        hospitalFeatures: ".fl-mapviz-hospital-features-content",
+        hospitalFeatures: ".fl-mapviz-hospital-features",
         hospitalFeaturesProvenance: ".fl-mapviz-hospital-features-prov",
         attribution: ".leaflet-control-attribution",
         resetButton: ".fl-mapviz-reset-filters",
@@ -310,7 +310,8 @@ fluid.defaults("fluid.covidMap.map", {
         query: "#fl-search-query"
     },
     styles: {
-        marker: "fl-mapviz-marker"
+        marker: "fl-mapviz-marker",
+        hideHospitalPanel: "fl-mapviz-hospital-panel-hidden"
     },
     markup: {
         marker: "<svg height=\"%height\" width=\"%width\"><use xlink:href=\"#%marker\" /></svg>"
@@ -433,10 +434,6 @@ fluid.defaults("fluid.covidMap.map", {
             source: "selectedIndex",
             target: "isHospitalShowing",
             func: "fluid.isValue"
-        },
-        showHospitalPanel: {
-            source: "isHospitalShowing",
-            target: "dom.hospitalPanel.visible"
         },
         onlyShowHospitalPanelOnMobile: {
             source: "isHospitalShowing",
@@ -583,6 +580,13 @@ fluid.defaults("fluid.covidMap.map", {
             priority: "last",
             func: "{query}.accept",
             args: [0]
+        },
+        "showHospitalPanel": {
+            path: "isHospitalShowing",
+            func: function (element, className, toggleFlag) {
+                element.toggleClass(className, !toggleFlag);
+            },
+            args: ["{that}.dom.hospitalPanel", "{that}.options.styles.hideHospitalPanel", "{change}.value"]
         }
     },
     components: {

--- a/src/js/covidMap.js
+++ b/src/js/covidMap.js
@@ -12,7 +12,7 @@ fluid.defaults("fluid.covidMap.hospitalRenderer", {
     gradeNames: ["fluid.modelComponent", "fluid.covidMap.visiblePanel"],
     selectors: {
         hospitalTitle: ".fl-mapviz-hospital-title",
-        hospitalDescription: ".fl-mapviz-hospital-description",
+        hospitalInfoPane: ".fl-mapviz-hospital",
         hospitalHours: ".fl-mapviz-hospital-hours",
         hospitalAddress: ".fl-mapviz-hospital-address",
         hospitalPhone:  ".fl-mapviz-hospital-phone",
@@ -23,7 +23,7 @@ fluid.defaults("fluid.covidMap.hospitalRenderer", {
             type: "fluid.expandButton",
             container: "{hospitalRenderer}.dom.expandButton",
             options: {
-                elementsToExpand: ["{hospitalRenderer}.dom.hospitalTitle", "{hospitalRenderer}.dom.hospitalDescription"]
+                elementsToExpand: ["{hospitalRenderer}.dom.hospitalTitle", "{hospitalRenderer}.dom.hospitalInfoPane"]
             }
         }
     },

--- a/src/js/covidMap.js
+++ b/src/js/covidMap.js
@@ -435,6 +435,13 @@ fluid.defaults("fluid.covidMap.map", {
             target: "isHospitalShowing",
             func: "fluid.isValue"
         },
+        toggleHospitalShowingClass: {
+            source: "isHospitalShowing",
+            target: {
+                segs: ["dom", "hospitalPanel", "class", "{that}.options.styles.hideHospitalPanel"]
+            },
+            func: x => !x
+        },
         onlyShowHospitalPanelOnMobile: {
             source: "isHospitalShowing",
             target: "visiblePanelOnMobileFlags",
@@ -580,13 +587,6 @@ fluid.defaults("fluid.covidMap.map", {
             priority: "last",
             func: "{query}.accept",
             args: [0]
-        },
-        "showHospitalPanel": {
-            path: "isHospitalShowing",
-            func: function (element, className, toggleFlag) {
-                element.toggleClass(className, !toggleFlag);
-            },
-            args: ["{that}.dom.hospitalPanel", "{that}.options.styles.hideHospitalPanel", "{change}.value"]
         }
     },
     components: {


### PR DESCRIPTION
This pull request fixes the un-scrollable issue with the hospital panel on the mobile view. The root cause is [this model relay](https://github.com/amb26/covid-data-monitor/blob/element-provenenance/src/js/covidMap.js#L437-L440) applies `display: block` to the hospital panel. It works great for the desktop view. But on the mobile view, this class overrides the default `display: flex` which is required for `overflow-y: scroll` to work on an inner div.

I also take the chance to move [this block of css](https://github.com/amb26/covid-data-monitor/blob/element-provenenance/src/css/scss/fluid-covid-map-viz.scss#L863-L882) the special mobile definition at line 862. The usual order for the responsive design is mobile first. See [this article](https://learningsolutionsmag.com/articles/2073/design-for-mobile-first-css-best-practices-for-responsive-html). In fluid-covid-map-viz.scss, line 649 is the breaking point. Css before it is for the mobile view and the after is for the desktop. The special section after line 862 is to define a special toggle class so that it's only acknowledged to the mobile view but not to the desktop view. The benefit is to avoid the complexity of handling this class in both views.

I also looked at why the show/hide button doesn't work for the hospital panel on the mobile view. I didn't implement my solution in this pull request in case you don't agree. What I think is `hospitalProvenance`, `hospitalFeatures`, `hospitalFeaturesProvenance` [components](https://github.com/amb26/covid-data-monitor/blob/element-provenenance/src/js/covidMap.js#L640-L677) should be subcomponents of `hospitalPanel` at line 611, so the `fluid.mapviz.visiblePanel` associated with it can toggle the visibility class on these subcomponents.